### PR TITLE
Adding clear button / Rajoute un bouton pour réinitialiser l'operation en cours

### DIFF
--- a/Macalculatrice/app/src/main/java/com/welcoming_machines/macalculatrice/MainActivity.java
+++ b/Macalculatrice/app/src/main/java/com/welcoming_machines/macalculatrice/MainActivity.java
@@ -41,6 +41,14 @@ public class MainActivity extends AppCompatActivity {
                 compute();
             }
         });
+
+        Button btnClear = (Button)findViewById(R.id.btnClear);
+        btnClear.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                clear();
+            }
+        });
     }
 
     private void updateDisplay() {
@@ -71,6 +79,14 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+
+    private void clear() {
+        op1 = 0;
+        op2 = 0;
+        operator = null;
+        isOp1 = true;
+        updateDisplay();
+    }
 
     public void setOperator(View v) {
         switch (v.getId()) {

--- a/Macalculatrice/app/src/main/res/layout/activity_main.xml
+++ b/Macalculatrice/app/src/main/res/layout/activity_main.xml
@@ -95,7 +95,6 @@
                 android:text="="
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_span="2"
                 android:id="@+id/btnEgal" />
 
             <Button
@@ -104,6 +103,12 @@
                 android:layout_height="wrap_content"
                 android:id="@+id/btnDiv"
                 android:onClick="setOperator" />
+
+            <Button
+                android:text="C"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/btnClear" />
         </TableRow>
     </TableLayout>
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Added a clear button for convenience - when I was testing it, I wasn't able to clear up from the second operand. 

Proposed new layout:
![screen shot 2018-11-17 at 2 12 59 am](https://user-images.githubusercontent.com/7889089/48658356-59183300-ea0e-11e8-8e49-ec2c8891ddd3.png)

(C'est pas tres beau, mais ca rend la calculatrice un peu plus facile a utiliser apres la premiere operation. Sinon le `op1` garde la valeur du resultat.)
